### PR TITLE
feat(#18): Add pull-to-refresh on kanban board

### DIFF
--- a/lib/screens/kanban_board_screen.dart
+++ b/lib/screens/kanban_board_screen.dart
@@ -249,70 +249,92 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
   }
 
   Widget _buildMobileBoard(BuildContext context, IssueBoardProvider provider) {
-    return Column(
-      children: [
-        // Done column header (collapsed, links to search)
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: DoneColumnHeader(
-            count: provider.doneIssues.length,
-            onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
+    return RefreshIndicator(
+      onRefresh: () => provider.fetchJobs(),
+      color: Theme.of(context).colorScheme.primary,
+      child: CustomScrollView(
+        slivers: [
+          // Done column header (collapsed, links to search)
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+              child: DoneColumnHeader(
+                count: provider.doneIssues.length,
+                onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
+              ),
+            ),
           ),
-        ),
-        // Swipeable columns
-        Expanded(
-          child: PageView.builder(
-            controller: _pageController,
-            onPageChanged: (page) => setState(() => _currentPage = page),
-            itemCount: _columnStatuses.length,
-            itemBuilder: (context, index) {
-              final status = _columnStatuses[index];
-              return Padding(
-                padding: const EdgeInsets.only(right: 12, bottom: 16, left: 4),
-                child: KanbanColumn(
-                  status: status,
-                  issues: provider.issuesForStatus(status),
-                  onIssueTap: (issue) => _openIssueDetail(context, issue),
-                  onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+          // Swipeable columns - needs to fill remaining space
+          SliverFillRemaining(
+            child: Column(
+              children: [
+                Expanded(
+                  child: PageView.builder(
+                    controller: _pageController,
+                    onPageChanged: (page) => setState(() => _currentPage = page),
+                    itemCount: _columnStatuses.length,
+                    itemBuilder: (context, index) {
+                      final status = _columnStatuses[index];
+                      return Padding(
+                        padding: const EdgeInsets.only(right: 12, bottom: 16, left: 4),
+                        child: KanbanColumn(
+                          status: status,
+                          issues: provider.issuesForStatus(status),
+                          onIssueTap: (issue) => _openIssueDetail(context, issue),
+                          onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                        ),
+                      );
+                    },
+                  ),
                 ),
-              );
-            },
+                // Page indicator
+                _buildPageIndicator(),
+              ],
+            ),
           ),
-        ),
-        // Page indicator
-        _buildPageIndicator(),
-      ],
+        ],
+      ),
     );
   }
 
   Widget _buildDesktopBoard(BuildContext context, IssueBoardProvider provider) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        children: [
-          // Done column header
-          DoneColumnHeader(
-            count: provider.doneIssues.length,
-            onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
-          ),
-          const SizedBox(height: 16),
-          // Main columns in a row
-          Expanded(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                for (int i = 0; i < _columnStatuses.length; i++) ...[
+    return RefreshIndicator(
+      onRefresh: () => provider.fetchJobs(),
+      color: Theme.of(context).colorScheme.primary,
+      child: CustomScrollView(
+        slivers: [
+          SliverPadding(
+            padding: const EdgeInsets.all(16),
+            sliver: SliverFillRemaining(
+              child: Column(
+                children: [
+                  // Done column header
+                  DoneColumnHeader(
+                    count: provider.doneIssues.length,
+                    onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
+                  ),
+                  const SizedBox(height: 16),
+                  // Main columns in a row
                   Expanded(
-                    child: KanbanColumn(
-                      status: _columnStatuses[i],
-                      issues: provider.issuesForStatus(_columnStatuses[i]),
-                      onIssueTap: (issue) => _openIssueDetail(context, issue),
-                      onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        for (int i = 0; i < _columnStatuses.length; i++) ...[
+                          Expanded(
+                            child: KanbanColumn(
+                              status: _columnStatuses[i],
+                              issues: provider.issuesForStatus(_columnStatuses[i]),
+                              onIssueTap: (issue) => _openIssueDetail(context, issue),
+                              onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                            ),
+                          ),
+                          if (i < _columnStatuses.length - 1) const SizedBox(width: 12),
+                        ],
+                      ],
                     ),
                   ),
-                  if (i < _columnStatuses.length - 1) const SizedBox(width: 12),
                 ],
-              ],
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- Add pull-to-refresh gesture to the kanban board screen
- Wrap both mobile and desktop layouts with `RefreshIndicator` widget
- When triggered, calls existing `IssueBoardProvider.fetchJobs()` to refresh data

## Acceptance Criteria
- [x] Given I am on the kanban board screen, When I pull down on the board content, Then a refresh indicator appears
- [x] Given the refresh indicator is visible, When the data finishes loading, Then the indicator disappears and the board shows updated data
- [x] Given I am on the mobile layout, When I pull down on the page view columns, Then the refresh gesture is detected
- [x] Given I am on the desktop layout, When I pull down (overscroll), Then the refresh gesture is detected

## Technical Approach
- **Mobile**: Wraps content in `CustomScrollView` with `SliverFillRemaining` to maintain `PageView` layout while enabling vertical pull gesture
- **Desktop**: Uses `CustomScrollView` with `SliverPadding` for consistent overscroll behavior with mouse/trackpad
- Uses `Theme.of(context).colorScheme.primary` for refresh indicator color

## Changes Made
### Files Modified
- `lib/screens/kanban_board_screen.dart` - Added `RefreshIndicator` wrapper to both `_buildMobileBoard` and `_buildDesktopBoard` methods

## Quality Gates
- [x] `flutter pub get` - Passed
- [x] `flutter analyze` - Passed (no errors, only pre-existing info-level warnings)
- [x] `flutter test` - Passed (61 tests)

## Mockups Reference
See: `docs/mockups/issue-18/`

---
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)