### PR TITLE
feat(#20): Add pull-to-refresh to kanban board

### DIFF
--- a/lib/screens/kanban_board_screen.dart
+++ b/lib/screens/kanban_board_screen.dart
@@ -249,73 +249,101 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
   }
 
   Widget _buildMobileBoard(BuildContext context, IssueBoardProvider provider) {
-    return Column(
-      children: [
-        // Done column header (collapsed, links to search)
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: DoneColumnHeader(
-            count: provider.doneIssues.length,
-            onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
-          ),
-        ),
-        // Swipeable columns
-        Expanded(
-          child: PageView.builder(
-            controller: _pageController,
-            onPageChanged: (page) => setState(() => _currentPage = page),
-            itemCount: _columnStatuses.length,
-            itemBuilder: (context, index) {
-              final status = _columnStatuses[index];
-              return Padding(
-                padding: const EdgeInsets.only(right: 12, bottom: 16, left: 4),
-                child: KanbanColumn(
-                  status: status,
-                  issues: provider.issuesForStatus(status),
-                  onIssueTap: (issue) => _openIssueDetail(context, issue),
-                  onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
-                ),
-              );
-            },
-          ),
-        ),
-        // Page indicator
-        _buildPageIndicator(),
-      ],
+    return RefreshIndicator(
+      onRefresh: () => provider.fetchJobs(),
+      color: Theme.of(context).colorScheme.primary,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: SizedBox(
+              height: constraints.maxHeight,
+              child: Column(
+                children: [
+                  // Done column header (collapsed, links to search)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                    child: DoneColumnHeader(
+                      count: provider.doneIssues.length,
+                      onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
+                    ),
+                  ),
+                  // Swipeable columns
+                  Expanded(
+                    child: PageView.builder(
+                      controller: _pageController,
+                      onPageChanged: (page) => setState(() => _currentPage = page),
+                      itemCount: _columnStatuses.length,
+                      itemBuilder: (context, index) {
+                        final status = _columnStatuses[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(right: 12, bottom: 16, left: 4),
+                          child: KanbanColumn(
+                            status: status,
+                            issues: provider.issuesForStatus(status),
+                            onIssueTap: (issue) => _openIssueDetail(context, issue),
+                            onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  // Page indicator
+                  _buildPageIndicator(),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
     );
   }
 
   Widget _buildDesktopBoard(BuildContext context, IssueBoardProvider provider) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        children: [
-          // Done column header
-          DoneColumnHeader(
-            count: provider.doneIssues.length,
-            onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
-          ),
-          const SizedBox(height: 16),
-          // Main columns in a row
-          Expanded(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                for (int i = 0; i < _columnStatuses.length; i++) ...[
-                  Expanded(
-                    child: KanbanColumn(
-                      status: _columnStatuses[i],
-                      issues: provider.issuesForStatus(_columnStatuses[i]),
-                      onIssueTap: (issue) => _openIssueDetail(context, issue),
-                      onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+    return RefreshIndicator(
+      onRefresh: () => provider.fetchJobs(),
+      color: Theme.of(context).colorScheme.primary,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: SizedBox(
+              height: constraints.maxHeight,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  children: [
+                    // Done column header
+                    DoneColumnHeader(
+                      count: provider.doneIssues.length,
+                      onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
                     ),
-                  ),
-                  if (i < _columnStatuses.length - 1) const SizedBox(width: 12),
-                ],
-              ],
+                    const SizedBox(height: 16),
+                    // Main columns in a row
+                    Expanded(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          for (int i = 0; i < _columnStatuses.length; i++) ...[
+                            Expanded(
+                              child: KanbanColumn(
+                                status: _columnStatuses[i],
+                                issues: provider.issuesForStatus(_columnStatuses[i]),
+                                onIssueTap: (issue) => _openIssueDetail(context, issue),
+                                onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                              ),
+                            ),
+                            if (i < _columnStatuses.length - 1) const SizedBox(width: 12),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ),
-          ),
-        ],
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Add pull-to-refresh gesture support to the Kanban board screen
- Users can now pull down on the content area to manually trigger a data refresh
- Works on both mobile (PageView) and desktop (Row) layouts

## Acceptance Criteria
- [x] Given I am on the Kanban board, When I pull down on the content area, Then a refresh indicator appears and data is fetched from the server
- [x] Given a refresh is in progress, When the API responds successfully, Then the refresh indicator hides and the board shows updated data
- [x] Given a refresh is in progress, When the API fails, Then the refresh indicator hides and the existing error handling displays the error
- [x] Given I am on the mobile layout, When I pull down on any column page, Then the refresh is triggered
- [x] Given I am on the desktop layout, When I pull down on the board content, Then the refresh is triggered

## Technical Approach
- Wrap both mobile (`_buildMobileBoard`) and desktop (`_buildDesktopBoard`) layouts with `RefreshIndicator`
- Use `SingleChildScrollView` with `AlwaysScrollableScrollPhysics` to enable pull gesture
- Use `LayoutBuilder` + `SizedBox(height: constraints.maxHeight)` to maintain proper sizing
- Connect `onRefresh` callback to existing `provider.fetchJobs()` method

## Changes Made
### Files Modified
- `lib/screens/kanban_board_screen.dart` - Added RefreshIndicator wrapping for both mobile and desktop layouts

## Quality Gates
- [x] `flutter pub get` - Passed
- [x] `flutter analyze` - Passed (only pre-existing info-level warnings)
- [x] `flutter test` - All 61 tests passed

## Mockups Reference
See: `docs/mockups/issue-20/`

---
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)