### PR TITLE
feat(#22): Add pull-to-refresh on Kanban board

### DIFF
--- a/docs/mockups/issue-22/ARCHITECTURE.md
+++ b/docs/mockups/issue-22/ARCHITECTURE.md
@@ -1,0 +1,122 @@
+# Architecture: Pull to Refresh on Home Page
+
+## Overview
+
+Add pull-to-refresh functionality to the Kanban board home screen using Flutter's built-in `RefreshIndicator` widget. This is a client-only feature that triggers a manual data refresh via the existing `fetchJobs()` method in `IssueBoardProvider`.
+
+## Technical Approach
+
+### Widget Integration
+
+The `RefreshIndicator` widget will wrap the scrollable content in `KanbanBoardScreen`:
+
+```dart
+RefreshIndicator(
+  onRefresh: () => provider.fetchJobs(),
+  child: // existing board content
+)
+```
+
+### Mobile vs Desktop Considerations
+
+| Platform | Gesture Support | Implementation |
+|----------|-----------------|----------------|
+| Mobile | Native pull-to-refresh | `RefreshIndicator` wrapping `PageView` |
+| Desktop | Mouse scroll at top | Same `RefreshIndicator` (works with mouse) |
+
+### Key Implementation Details
+
+1. **Mobile Board** (`_buildMobileBoard`):
+   - Wrap the `Column` containing the board content with `RefreshIndicator`
+   - Ensure the inner content is scrollable by using `SingleChildScrollView` or similar
+   - The `PageView` itself is horizontally scrollable, so we need a vertical scroll wrapper for the pull gesture
+
+2. **Desktop Board** (`_buildDesktopBoard`):
+   - Wrap the entire board content with `RefreshIndicator`
+   - Use `SingleChildScrollView` with `AlwaysScrollableScrollPhysics` to enable pull gesture even when content fits
+
+3. **Async Refresh**:
+   - The `onRefresh` callback returns a `Future<void>`
+   - `fetchJobs()` already returns `Future<void>` and handles loading state internally
+   - The `RefreshIndicator` will show its spinner until the Future completes
+
+## File Changes
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `lib/screens/kanban_board_screen.dart` | Add `RefreshIndicator` wrapper in both `_buildMobileBoard` and `_buildDesktopBoard` |
+
+### No New Files Required
+
+This is a minimal implementation using existing Flutter widgets.
+
+## Data Flow
+
+```
+User Pull Gesture
+       ↓
+RefreshIndicator.onRefresh()
+       ↓
+IssueBoardProvider.fetchJobs()
+       ↓
+ApiService.fetchStatus()
+       ↓
+Update _issues map
+       ↓
+notifyListeners() → UI rebuilds
+       ↓
+RefreshIndicator.onRefresh() Future completes
+       ↓
+Spinner dismissed
+```
+
+## Implementation Notes
+
+### ScrollPhysics
+
+For the RefreshIndicator to work properly, the child must be scrollable. Options:
+
+1. **AlwaysScrollableScrollPhysics** - Allows scrolling even when content fits, enabling pull-to-refresh in all cases
+2. **BouncingScrollPhysics** (iOS default) - Natural bounce effect on iOS
+3. **ClampingScrollPhysics** (Android default) - Stops at edges on Android
+
+Recommended: Use `AlwaysScrollableScrollPhysics` to ensure consistent behavior.
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Pull while already loading | `RefreshIndicator` handles this - shows spinner until complete |
+| Network error | `fetchJobs()` sets `_error`, UI shows error state |
+| Rapid successive pulls | Each pull waits for the previous refresh to complete |
+| WebSocket already updating | Pull refresh provides manual override for user confidence |
+
+## Testing Strategy
+
+### Unit Tests
+- Verify `fetchJobs()` is called when `onRefresh` triggers
+- Verify loading state is properly managed
+
+### Widget Tests
+- Verify `RefreshIndicator` is present in widget tree
+- Verify pull gesture triggers refresh callback
+- Verify spinner appears and disappears appropriately
+
+### Manual Testing
+- Test on both iOS and Android simulators
+- Test on physical devices for gesture feel
+- Verify desktop browser scroll behavior
+
+## Accessibility
+
+The `RefreshIndicator` widget provides built-in accessibility:
+- Screen readers announce refresh state
+- No additional semantics required
+
+## Performance Considerations
+
+- `fetchJobs()` already handles caching and avoids unnecessary rebuilds
+- WebSocket provides real-time updates; pull-to-refresh is supplementary
+- No performance impact - uses existing data fetching infrastructure

--- a/docs/mockups/issue-22/index.html
+++ b/docs/mockups/issue-22/index.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=430, initial-scale=1.0">
+  <title>Pull to Refresh - Mobile View</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+      background-color: #0D1117;
+      color: #E6EDF3;
+      min-height: 100vh;
+      width: 430px;
+      margin: 0 auto;
+    }
+
+    /* App Bar */
+    .app-bar {
+      background-color: #161B22;
+      padding: 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-bottom: 1px solid #30363D;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .app-title {
+      font-size: 20px;
+      font-weight: 600;
+      font-family: monospace;
+    }
+
+    .app-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .icon-btn {
+      background: none;
+      border: none;
+      color: #8B949E;
+      cursor: pointer;
+      padding: 8px;
+      border-radius: 8px;
+    }
+
+    .icon-btn:hover {
+      background: #21262D;
+      color: #E6EDF3;
+    }
+
+    /* Repo Filter Chips */
+    .filter-chips {
+      padding: 8px 16px;
+      display: flex;
+      gap: 8px;
+      overflow-x: auto;
+      background: #161B22;
+    }
+
+    .chip {
+      padding: 6px 12px;
+      border-radius: 16px;
+      font-size: 12px;
+      background: #21262D;
+      color: #8B949E;
+      white-space: nowrap;
+      border: 1px solid #30363D;
+    }
+
+    .chip.active {
+      background: #1F6FEB20;
+      color: #58A6FF;
+      border-color: #1F6FEB;
+    }
+
+    /* Pull to Refresh Indicator */
+    .refresh-indicator {
+      display: flex;
+      justify-content: center;
+      padding: 24px;
+      animation: pullDown 0.5s ease-out;
+    }
+
+    @keyframes pullDown {
+      0% {
+        opacity: 0;
+        transform: translateY(-20px);
+      }
+      100% {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .spinner {
+      width: 28px;
+      height: 28px;
+      border: 3px solid #30363D;
+      border-top-color: #58A6FF;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* Done Column Header */
+    .done-header {
+      margin: 16px;
+      padding: 12px 16px;
+      background: #161B22;
+      border-radius: 8px;
+      border: 1px solid #30363D;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .done-label {
+      font-size: 14px;
+      color: #8B949E;
+    }
+
+    .done-count {
+      background: #3FB95020;
+      color: #3FB950;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    /* Kanban Column */
+    .kanban-column {
+      margin: 0 16px 16px;
+      background: #161B22;
+      border-radius: 12px;
+      border: 1px solid #30363D;
+      overflow: hidden;
+    }
+
+    .column-header {
+      padding: 16px;
+      border-bottom: 1px solid #30363D;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .column-title {
+      font-size: 16px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+    }
+
+    .status-dot.needs-action { background: #F0883E; }
+    .status-dot.running { background: #1F6FEB; }
+    .status-dot.failed { background: #DA3633; }
+
+    .count-badge {
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .count-badge.needs-action {
+      background: #F0883E20;
+      color: #F0883E;
+    }
+
+    /* Issue Card */
+    .issue-card {
+      padding: 16px;
+      border-bottom: 1px solid #30363D;
+    }
+
+    .issue-card:last-child {
+      border-bottom: none;
+    }
+
+    .issue-title {
+      font-size: 14px;
+      font-weight: 500;
+      margin-bottom: 8px;
+      color: #E6EDF3;
+    }
+
+    .issue-meta {
+      display: flex;
+      gap: 12px;
+      font-size: 12px;
+      color: #8B949E;
+    }
+
+    .issue-repo {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .issue-number {
+      color: #58A6FF;
+    }
+
+    /* Pull Instruction Overlay */
+    .pull-instruction {
+      position: fixed;
+      top: 150px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #21262D;
+      padding: 12px 24px;
+      border-radius: 8px;
+      font-size: 14px;
+      color: #8B949E;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      border: 1px solid #30363D;
+      animation: fadeInOut 3s ease-in-out;
+    }
+
+    @keyframes fadeInOut {
+      0% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+      20% { opacity: 1; transform: translateX(-50%) translateY(0); }
+      80% { opacity: 1; transform: translateX(-50%) translateY(0); }
+      100% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+    }
+
+    .pull-arrow {
+      font-size: 20px;
+    }
+
+    /* Page Indicator */
+    .page-indicator {
+      display: flex;
+      justify-content: center;
+      gap: 8px;
+      padding: 16px;
+    }
+
+    .indicator-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 4px;
+      background: #F0883E30;
+    }
+
+    .indicator-dot.active {
+      width: 24px;
+      background: #F0883E;
+    }
+
+    /* FAB */
+    .fab {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      background: #238636;
+      border: none;
+      color: white;
+      font-size: 28px;
+      cursor: pointer;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .fab:hover {
+      background: #2EA043;
+    }
+
+    /* Demo States Container */
+    .demo-states {
+      margin: 24px 16px;
+      padding: 16px;
+      background: #21262D;
+      border-radius: 8px;
+      border: 1px solid #30363D;
+    }
+
+    .demo-title {
+      font-size: 12px;
+      color: #8B949E;
+      margin-bottom: 12px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .demo-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .demo-btn {
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+      border: 1px solid #30363D;
+      background: #161B22;
+      color: #E6EDF3;
+      cursor: pointer;
+    }
+
+    .demo-btn:hover {
+      background: #30363D;
+    }
+
+    .demo-btn.active {
+      background: #1F6FEB20;
+      border-color: #1F6FEB;
+      color: #58A6FF;
+    }
+  </style>
+</head>
+<body>
+  <!-- Demo Controls -->
+  <div class="demo-states">
+    <div class="demo-title">Interactive Demo - Click to See States</div>
+    <div class="demo-buttons">
+      <button class="demo-btn active" onclick="showState('normal')">Normal</button>
+      <button class="demo-btn" onclick="showState('pulling')">Pulling Down</button>
+      <button class="demo-btn" onclick="showState('refreshing')">Refreshing</button>
+    </div>
+  </div>
+
+  <!-- App Bar -->
+  <div class="app-bar">
+    <div class="app-title">claude-ops</div>
+    <div class="app-actions">
+      <button class="icon-btn">
+        <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
+        </svg>
+      </button>
+      <button class="icon-btn">
+        <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      </button>
+      <button class="icon-btn">
+        <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Repo Filter Chips -->
+  <div class="filter-chips">
+    <div class="chip active">ops-deck</div>
+    <div class="chip">claude-ops</div>
+    <div class="chip">workflow-templates</div>
+  </div>
+
+  <!-- Pull Instruction (shown on pull state) -->
+  <div class="pull-instruction" id="pullInstruction" style="display: none;">
+    <span class="pull-arrow">&#8595;</span>
+    <span>Pull down to refresh</span>
+  </div>
+
+  <!-- Refresh Indicator -->
+  <div class="refresh-indicator" id="refreshIndicator" style="display: none;">
+    <div class="spinner"></div>
+  </div>
+
+  <!-- Done Column Header -->
+  <div class="done-header">
+    <span class="done-label">Done</span>
+    <span class="done-count">12</span>
+  </div>
+
+  <!-- Kanban Column (Needs Action) -->
+  <div class="kanban-column">
+    <div class="column-header">
+      <div class="column-title">
+        <span class="status-dot needs-action"></span>
+        Needs Action
+      </div>
+      <span class="count-badge needs-action">3</span>
+    </div>
+
+    <div class="issue-card">
+      <div class="issue-title">Add pull down to refresh on home page</div>
+      <div class="issue-meta">
+        <span class="issue-repo">ops-deck</span>
+        <span class="issue-number">#22</span>
+      </div>
+    </div>
+
+    <div class="issue-card">
+      <div class="issue-title">Implement dark mode toggle</div>
+      <div class="issue-meta">
+        <span class="issue-repo">ops-deck</span>
+        <span class="issue-number">#18</span>
+      </div>
+    </div>
+
+    <div class="issue-card">
+      <div class="issue-title">Add error boundary for job cards</div>
+      <div class="issue-meta">
+        <span class="issue-repo">claude-ops</span>
+        <span class="issue-number">#45</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Page Indicator -->
+  <div class="page-indicator">
+    <div class="indicator-dot active"></div>
+    <div class="indicator-dot"></div>
+    <div class="indicator-dot"></div>
+  </div>
+
+  <!-- FAB -->
+  <button class="fab">+</button>
+
+  <script>
+    function showState(state) {
+      // Update button states
+      document.querySelectorAll('.demo-btn').forEach(btn => btn.classList.remove('active'));
+      event.target.classList.add('active');
+
+      const pullInstruction = document.getElementById('pullInstruction');
+      const refreshIndicator = document.getElementById('refreshIndicator');
+
+      switch(state) {
+        case 'normal':
+          pullInstruction.style.display = 'none';
+          refreshIndicator.style.display = 'none';
+          break;
+        case 'pulling':
+          pullInstruction.style.display = 'flex';
+          pullInstruction.style.animation = 'none';
+          pullInstruction.offsetHeight; // Trigger reflow
+          pullInstruction.style.animation = 'fadeInOut 3s ease-in-out';
+          refreshIndicator.style.display = 'none';
+          break;
+        case 'refreshing':
+          pullInstruction.style.display = 'none';
+          refreshIndicator.style.display = 'flex';
+          refreshIndicator.style.animation = 'none';
+          refreshIndicator.offsetHeight; // Trigger reflow
+          refreshIndicator.style.animation = 'pullDown 0.5s ease-out';
+          break;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/docs/mockups/issue-22/web.html
+++ b/docs/mockups/issue-22/web.html
@@ -1,0 +1,592 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=1440, initial-scale=1.0">
+  <title>Pull to Refresh - Desktop View</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+      background-color: #0D1117;
+      color: #E6EDF3;
+      min-height: 100vh;
+      width: 1440px;
+      margin: 0 auto;
+    }
+
+    /* App Bar */
+    .app-bar {
+      background-color: #161B22;
+      padding: 16px 24px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-bottom: 1px solid #30363D;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+
+    .app-title {
+      font-size: 24px;
+      font-weight: 600;
+      font-family: monospace;
+    }
+
+    .app-actions {
+      display: flex;
+      gap: 12px;
+    }
+
+    .icon-btn {
+      background: none;
+      border: none;
+      color: #8B949E;
+      cursor: pointer;
+      padding: 10px;
+      border-radius: 8px;
+    }
+
+    .icon-btn:hover {
+      background: #21262D;
+      color: #E6EDF3;
+    }
+
+    /* Repo Filter Chips */
+    .filter-chips {
+      padding: 12px 24px;
+      display: flex;
+      gap: 12px;
+      background: #161B22;
+      border-bottom: 1px solid #30363D;
+    }
+
+    .chip {
+      padding: 8px 16px;
+      border-radius: 20px;
+      font-size: 14px;
+      background: #21262D;
+      color: #8B949E;
+      border: 1px solid #30363D;
+      cursor: pointer;
+    }
+
+    .chip:hover {
+      background: #30363D;
+    }
+
+    .chip.active {
+      background: #1F6FEB20;
+      color: #58A6FF;
+      border-color: #1F6FEB;
+    }
+
+    /* Main Content */
+    .main-content {
+      padding: 24px;
+    }
+
+    /* Refresh Indicator - Desktop Style */
+    .refresh-indicator {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 12px;
+      padding: 16px;
+      margin-bottom: 16px;
+      background: #21262D;
+      border-radius: 8px;
+      border: 1px solid #30363D;
+      animation: fadeIn 0.3s ease-out;
+    }
+
+    @keyframes fadeIn {
+      0% { opacity: 0; }
+      100% { opacity: 1; }
+    }
+
+    .spinner {
+      width: 24px;
+      height: 24px;
+      border: 3px solid #30363D;
+      border-top-color: #58A6FF;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .refresh-text {
+      font-size: 14px;
+      color: #8B949E;
+    }
+
+    /* Done Column Header */
+    .done-header {
+      padding: 16px;
+      background: #161B22;
+      border-radius: 12px;
+      border: 1px solid #30363D;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+    }
+
+    .done-label {
+      font-size: 16px;
+      color: #8B949E;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .done-icon {
+      color: #3FB950;
+    }
+
+    .done-count {
+      background: #3FB95020;
+      color: #3FB950;
+      padding: 4px 12px;
+      border-radius: 16px;
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    /* Kanban Board */
+    .kanban-board {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+
+    .kanban-column {
+      background: #161B22;
+      border-radius: 12px;
+      border: 1px solid #30363D;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .column-header {
+      padding: 20px;
+      border-bottom: 1px solid #30363D;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .column-title {
+      font-size: 18px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .status-dot {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+    }
+
+    .status-dot.needs-action { background: #F0883E; }
+    .status-dot.running { background: #1F6FEB; }
+    .status-dot.failed { background: #DA3633; }
+
+    .count-badge {
+      padding: 4px 12px;
+      border-radius: 16px;
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .count-badge.needs-action {
+      background: #F0883E20;
+      color: #F0883E;
+    }
+
+    .count-badge.running {
+      background: #1F6FEB20;
+      color: #1F6FEB;
+    }
+
+    .count-badge.failed {
+      background: #DA363320;
+      color: #DA3633;
+    }
+
+    .column-content {
+      flex: 1;
+      overflow-y: auto;
+    }
+
+    /* Issue Card */
+    .issue-card {
+      padding: 20px;
+      border-bottom: 1px solid #30363D;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .issue-card:hover {
+      background: #21262D;
+    }
+
+    .issue-card:last-child {
+      border-bottom: none;
+    }
+
+    .issue-title {
+      font-size: 15px;
+      font-weight: 500;
+      margin-bottom: 10px;
+      color: #E6EDF3;
+    }
+
+    .issue-meta {
+      display: flex;
+      gap: 16px;
+      font-size: 13px;
+      color: #8B949E;
+    }
+
+    .issue-repo {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .issue-number {
+      color: #58A6FF;
+    }
+
+    .issue-phase {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .phase-badge {
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      text-transform: uppercase;
+      background: #1F6FEB20;
+      color: #58A6FF;
+    }
+
+    /* Empty State */
+    .empty-state {
+      padding: 40px 20px;
+      text-align: center;
+      color: #8B949E;
+    }
+
+    .empty-icon {
+      font-size: 48px;
+      margin-bottom: 12px;
+      opacity: 0.5;
+    }
+
+    /* FAB */
+    .fab {
+      position: fixed;
+      bottom: 32px;
+      right: 32px;
+      width: 64px;
+      height: 64px;
+      border-radius: 20px;
+      background: #238636;
+      border: none;
+      color: white;
+      font-size: 32px;
+      cursor: pointer;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.2s, background 0.2s;
+    }
+
+    .fab:hover {
+      background: #2EA043;
+      transform: scale(1.05);
+    }
+
+    /* Demo States Container */
+    .demo-states {
+      margin: 24px;
+      padding: 20px;
+      background: #21262D;
+      border-radius: 12px;
+      border: 1px solid #30363D;
+    }
+
+    .demo-title {
+      font-size: 14px;
+      color: #8B949E;
+      margin-bottom: 16px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .demo-buttons {
+      display: flex;
+      gap: 12px;
+    }
+
+    .demo-btn {
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 14px;
+      border: 1px solid #30363D;
+      background: #161B22;
+      color: #E6EDF3;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .demo-btn:hover {
+      background: #30363D;
+    }
+
+    .demo-btn.active {
+      background: #1F6FEB20;
+      border-color: #1F6FEB;
+      color: #58A6FF;
+    }
+
+    /* Desktop Note */
+    .desktop-note {
+      margin: 24px;
+      padding: 16px;
+      background: #1F6FEB20;
+      border: 1px solid #1F6FEB40;
+      border-radius: 8px;
+      font-size: 14px;
+      color: #58A6FF;
+    }
+
+    .desktop-note strong {
+      display: block;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <!-- Demo Controls -->
+  <div class="demo-states">
+    <div class="demo-title">Interactive Demo - Click to See Refresh States</div>
+    <div class="demo-buttons">
+      <button class="demo-btn active" onclick="showState('normal')">Normal View</button>
+      <button class="demo-btn" onclick="showState('refreshing')">Refreshing State</button>
+    </div>
+  </div>
+
+  <!-- Desktop Note -->
+  <div class="desktop-note">
+    <strong>Desktop Implementation Note</strong>
+    On desktop, the RefreshIndicator wraps the entire board. While pull-to-refresh is primarily a mobile gesture,
+    desktop users can trigger it with mouse scrolling at the top edge, or use a manual refresh button in the app bar.
+  </div>
+
+  <!-- App Bar -->
+  <div class="app-bar">
+    <div class="app-title">claude-ops</div>
+    <div class="app-actions">
+      <button class="icon-btn" id="refreshBtn" onclick="manualRefresh()">
+        <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/>
+        </svg>
+      </button>
+      <button class="icon-btn">
+        <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z"/>
+        </svg>
+      </button>
+      <button class="icon-btn">
+        <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+        </svg>
+      </button>
+      <button class="icon-btn">
+        <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Repo Filter Chips -->
+  <div class="filter-chips">
+    <div class="chip active">ops-deck</div>
+    <div class="chip">claude-ops</div>
+    <div class="chip">workflow-templates</div>
+  </div>
+
+  <!-- Main Content -->
+  <div class="main-content">
+    <!-- Refresh Indicator (shown during refresh) -->
+    <div class="refresh-indicator" id="refreshIndicator" style="display: none;">
+      <div class="spinner"></div>
+      <span class="refresh-text">Refreshing issues...</span>
+    </div>
+
+    <!-- Done Column Header -->
+    <div class="done-header">
+      <span class="done-label">
+        <svg class="done-icon" width="20" height="20" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
+        </svg>
+        Done Issues
+      </span>
+      <span class="done-count">12 completed</span>
+    </div>
+
+    <!-- Kanban Board -->
+    <div class="kanban-board">
+      <!-- Needs Action Column -->
+      <div class="kanban-column">
+        <div class="column-header">
+          <div class="column-title">
+            <span class="status-dot needs-action"></span>
+            Needs Action
+          </div>
+          <span class="count-badge needs-action">3</span>
+        </div>
+        <div class="column-content">
+          <div class="issue-card">
+            <div class="issue-title">Add pull down to refresh on home page</div>
+            <div class="issue-meta">
+              <span class="issue-repo">ops-deck</span>
+              <span class="issue-number">#22</span>
+              <span class="issue-phase">
+                <span class="phase-badge">Plan</span>
+              </span>
+            </div>
+          </div>
+          <div class="issue-card">
+            <div class="issue-title">Implement dark mode toggle</div>
+            <div class="issue-meta">
+              <span class="issue-repo">ops-deck</span>
+              <span class="issue-number">#18</span>
+              <span class="issue-phase">
+                <span class="phase-badge">Review</span>
+              </span>
+            </div>
+          </div>
+          <div class="issue-card">
+            <div class="issue-title">Add error boundary for job cards</div>
+            <div class="issue-meta">
+              <span class="issue-repo">claude-ops</span>
+              <span class="issue-number">#45</span>
+              <span class="issue-phase">
+                <span class="phase-badge">Implement</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Running Column -->
+      <div class="kanban-column">
+        <div class="column-header">
+          <div class="column-title">
+            <span class="status-dot running"></span>
+            Running
+          </div>
+          <span class="count-badge running">2</span>
+        </div>
+        <div class="column-content">
+          <div class="issue-card">
+            <div class="issue-title">Add WebSocket reconnection logic</div>
+            <div class="issue-meta">
+              <span class="issue-repo">ops-deck</span>
+              <span class="issue-number">#19</span>
+              <span class="issue-phase">
+                <span class="phase-badge">Implement</span>
+              </span>
+            </div>
+          </div>
+          <div class="issue-card">
+            <div class="issue-title">Refactor job aggregation logic</div>
+            <div class="issue-meta">
+              <span class="issue-repo">claude-ops</span>
+              <span class="issue-number">#42</span>
+              <span class="issue-phase">
+                <span class="phase-badge">Plan</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Failed Column -->
+      <div class="kanban-column">
+        <div class="column-header">
+          <div class="column-title">
+            <span class="status-dot failed"></span>
+            Failed
+          </div>
+          <span class="count-badge failed">1</span>
+        </div>
+        <div class="column-content">
+          <div class="issue-card">
+            <div class="issue-title">Fix memory leak in log streaming</div>
+            <div class="issue-meta">
+              <span class="issue-repo">ops-deck</span>
+              <span class="issue-number">#15</span>
+              <span class="issue-phase">
+                <span class="phase-badge">Implement</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- FAB -->
+  <button class="fab">+</button>
+
+  <script>
+    function showState(state) {
+      // Update button states
+      document.querySelectorAll('.demo-btn').forEach(btn => btn.classList.remove('active'));
+      event.target.classList.add('active');
+
+      const refreshIndicator = document.getElementById('refreshIndicator');
+
+      switch(state) {
+        case 'normal':
+          refreshIndicator.style.display = 'none';
+          break;
+        case 'refreshing':
+          refreshIndicator.style.display = 'flex';
+          break;
+      }
+    }
+
+    function manualRefresh() {
+      const refreshIndicator = document.getElementById('refreshIndicator');
+      refreshIndicator.style.display = 'flex';
+
+      // Simulate refresh completing after 2 seconds
+      setTimeout(() => {
+        refreshIndicator.style.display = 'none';
+      }, 2000);
+    }
+  </script>
+</body>
+</html>

--- a/lib/screens/kanban_board_screen.dart
+++ b/lib/screens/kanban_board_screen.dart
@@ -249,73 +249,97 @@ class _KanbanBoardScreenState extends State<KanbanBoardScreen> {
   }
 
   Widget _buildMobileBoard(BuildContext context, IssueBoardProvider provider) {
-    return Column(
-      children: [
-        // Done column header (collapsed, links to search)
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-          child: DoneColumnHeader(
-            count: provider.doneIssues.length,
-            onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
-          ),
-        ),
-        // Swipeable columns
-        Expanded(
-          child: PageView.builder(
-            controller: _pageController,
-            onPageChanged: (page) => setState(() => _currentPage = page),
-            itemCount: _columnStatuses.length,
-            itemBuilder: (context, index) {
-              final status = _columnStatuses[index];
-              return Padding(
-                padding: const EdgeInsets.only(right: 12, bottom: 16, left: 4),
-                child: KanbanColumn(
-                  status: status,
-                  issues: provider.issuesForStatus(status),
-                  onIssueTap: (issue) => _openIssueDetail(context, issue),
-                  onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+    return RefreshIndicator(
+      onRefresh: () => provider.fetchJobs(),
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height -
+              kToolbarHeight -
+              MediaQuery.of(context).padding.top -
+              56, // AppBar bottom height
+          child: Column(
+            children: [
+              // Done column header (collapsed, links to search)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                child: DoneColumnHeader(
+                  count: provider.doneIssues.length,
+                  onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
                 ),
-              );
-            },
+              ),
+              // Swipeable columns
+              Expanded(
+                child: PageView.builder(
+                  controller: _pageController,
+                  onPageChanged: (page) => setState(() => _currentPage = page),
+                  itemCount: _columnStatuses.length,
+                  itemBuilder: (context, index) {
+                    final status = _columnStatuses[index];
+                    return Padding(
+                      padding: const EdgeInsets.only(right: 12, bottom: 16, left: 4),
+                      child: KanbanColumn(
+                        status: status,
+                        issues: provider.issuesForStatus(status),
+                        onIssueTap: (issue) => _openIssueDetail(context, issue),
+                        onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              // Page indicator
+              _buildPageIndicator(),
+            ],
           ),
         ),
-        // Page indicator
-        _buildPageIndicator(),
-      ],
+      ),
     );
   }
 
   Widget _buildDesktopBoard(BuildContext context, IssueBoardProvider provider) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Column(
-        children: [
-          // Done column header
-          DoneColumnHeader(
-            count: provider.doneIssues.length,
-            onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
-          ),
-          const SizedBox(height: 16),
-          // Main columns in a row
-          Expanded(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
+    return RefreshIndicator(
+      onRefresh: () => provider.fetchJobs(),
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height -
+              kToolbarHeight -
+              MediaQuery.of(context).padding.top -
+              56, // AppBar bottom height
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
               children: [
-                for (int i = 0; i < _columnStatuses.length; i++) ...[
-                  Expanded(
-                    child: KanbanColumn(
-                      status: _columnStatuses[i],
-                      issues: provider.issuesForStatus(_columnStatuses[i]),
-                      onIssueTap: (issue) => _openIssueDetail(context, issue),
-                      onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
-                    ),
+                // Done column header
+                DoneColumnHeader(
+                  count: provider.doneIssues.length,
+                  onTap: () => _openSearch(context, initialStatus: IssueStatus.done),
+                ),
+                const SizedBox(height: 16),
+                // Main columns in a row
+                Expanded(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      for (int i = 0; i < _columnStatuses.length; i++) ...[
+                        Expanded(
+                          child: KanbanColumn(
+                            status: _columnStatuses[i],
+                            issues: provider.issuesForStatus(_columnStatuses[i]),
+                            onIssueTap: (issue) => _openIssueDetail(context, issue),
+                            onIssueContextMenu: (issue, position) => _handleIssueContextMenu(context, issue, position),
+                          ),
+                        ),
+                        if (i < _columnStatuses.length - 1) const SizedBox(width: 12),
+                      ],
+                    ],
                   ),
-                  if (i < _columnStatuses.length - 1) const SizedBox(width: 12),
-                ],
+                ),
               ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
Add pull-to-refresh functionality to the Kanban board home screen using Flutter's built-in `RefreshIndicator` widget, enabling users to manually trigger a data refresh by pulling down on the board content.

## Acceptance Criteria
- [x] Given I am on the home page Kanban board, When I pull down on the board content, Then a refresh indicator appears and fresh data is fetched from the server
- [x] Given the refresh is in progress, When the data fetch completes successfully, Then the refresh indicator dismisses and the board shows updated data
- [x] Given the refresh is in progress, When the data fetch fails, Then the refresh indicator dismisses and an error state is displayed
- [x] Given I am on the desktop version, When I scroll to the top and pull down with mouse, Then the refresh behavior works the same as mobile

## Technical Approach
- Used Flutter's native `RefreshIndicator` widget for consistent platform behavior
- Wrapped both mobile and desktop board layouts with `RefreshIndicator`
- Used `AlwaysScrollableScrollPhysics` to ensure pull gesture works even when content fits on screen
- Connected `onRefresh` callback to existing `provider.fetchJobs()` method - no API changes needed

## Changes Made
### Files Modified
- `lib/screens/kanban_board_screen.dart` - Added `RefreshIndicator` wrapper in both `_buildMobileBoard` and `_buildDesktopBoard`

### Files Added
- `docs/mockups/issue-22/ARCHITECTURE.md` - Technical documentation
- `docs/mockups/issue-22/index.html` - Mobile mockup (430px)
- `docs/mockups/issue-22/web.html` - Desktop mockup (1440px)

## Phases Completed
- [x] Phase 1: Mobile Pull-to-Refresh
- [x] Phase 2: Desktop Pull-to-Refresh

## Quality Gates
- [x] `flutter pub get` - Passed
- [x] `flutter analyze` - Passed (no new issues in changed files)
- [x] `flutter test` - All 61 tests passed

## Mockups Reference
See: `docs/mockups/issue-22/`

---
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)