### PR TITLE
feat: Add confidence scores display (Phase 3)

### DIFF
--- a/.claude/commands/implement-headless.md
+++ b/.claude/commands/implement-headless.md
@@ -93,6 +93,56 @@ CATEGORY: architecture
 
 ---
 
+## Confidence Assessment
+
+After completing implementation, provide an overall confidence assessment using this EXACT format:
+
+```
+<<<CONFIDENCE>>>
+SCORE: [0.0-1.0, e.g., 0.85]
+ASSESSMENT: [HIGH|MEDIUM|LOW]
+REASONING: [Why this confidence level - what's certain vs uncertain about the implementation]
+RISKS: [Any concerns, edge cases, or unknowns that may need attention, or "None identified"]
+<<<END_CONFIDENCE>>>
+```
+
+### Confidence Levels:
+- **HIGH (0.8-1.0):** Standard patterns, well-understood requirements, comprehensive tests
+- **MEDIUM (0.5-0.8):** Some complexity, minor unknowns, or limited test coverage
+- **LOW (0.0-0.5):** Significant unknowns, complex integrations, or potential edge cases
+
+### Example - High Confidence:
+```
+<<<CONFIDENCE>>>
+SCORE: 0.90
+ASSESSMENT: HIGH
+REASONING: Straightforward feature using well-established Flutter patterns. RefreshIndicator is the standard approach with predictable behavior. All quality gates passed and existing tests continue to work.
+RISKS: None identified - this is a common pattern used throughout the codebase.
+<<<END_CONFIDENCE>>>
+```
+
+### Example - Medium Confidence:
+```
+<<<CONFIDENCE>>>
+SCORE: 0.65
+ASSESSMENT: MEDIUM
+REASONING: Core functionality works but involves new WebSocket integration that wasn't fully testable in isolation. Manual testing recommended for connection edge cases.
+RISKS: WebSocket reconnection logic may need tuning based on real-world network conditions; Error handling for malformed server responses is minimal.
+<<<END_CONFIDENCE>>>
+```
+
+### Example - Low Confidence:
+```
+<<<CONFIDENCE>>>
+SCORE: 0.40
+ASSESSMENT: LOW
+REASONING: Complex state management changes touching multiple providers. Tests pass but coverage is limited for the new interaction patterns.
+RISKS: Race conditions possible between providers; Memory leaks if listeners not properly disposed; Needs thorough manual testing before merge.
+<<<END_CONFIDENCE>>>
+```
+
+---
+
 ## Prerequisites
 
 **Read these before proceeding:**
@@ -542,6 +592,15 @@ REASONING: [Why this approach]
 ALTERNATIVES: [What else was considered]
 CATEGORY: [category]
 <<<END_DECISION>>>
+
+## Confidence Assessment
+
+<<<CONFIDENCE>>>
+SCORE: [0.0-1.0]
+ASSESSMENT: [HIGH|MEDIUM|LOW]
+REASONING: [Why this confidence level]
+RISKS: [Any concerns or unknowns, or "None identified"]
+<<<END_CONFIDENCE>>>
 
 ## Changes Made
 ### Files Modified

--- a/lib/providers/issue_board_provider.dart
+++ b/lib/providers/issue_board_provider.dart
@@ -626,6 +626,12 @@ class IssueBoardProvider with ChangeNotifier {
     return job?.decisions ?? [];
   }
 
+  /// Get confidence for a specific job
+  JobConfidence? getJobConfidence(String jobId) {
+    final job = getJob(jobId);
+    return job?.confidence;
+  }
+
   /// Proceed with issue (trigger next phase) - legacy method
   Future<bool> proceedWithIssue(String repo, int issueNum) async {
     try {

--- a/lib/widgets/confidence/confidence_indicator.dart
+++ b/lib/widgets/confidence/confidence_indicator.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import '../../models/job_model.dart';
+
+/// A visual indicator showing Claude's confidence level
+class ConfidenceIndicator extends StatelessWidget {
+  final JobConfidence confidence;
+  final bool compact;
+  final VoidCallback? onTap;
+
+  const ConfidenceIndicator({
+    super.key,
+    required this.confidence,
+    this.compact = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Color(confidence.colorValue);
+
+    if (compact) {
+      return _buildCompact(color);
+    }
+    return _buildFull(color);
+  }
+
+  Widget _buildCompact(Color color) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(4),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: color.withOpacity(0.2),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: color.withOpacity(0.4)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              _getIcon(),
+              size: 12,
+              color: color,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              confidence.percentageString,
+              style: TextStyle(
+                fontFamily: 'monospace',
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFull(Color color) {
+    return Container(
+      decoration: BoxDecoration(
+        color: const Color(0xFF0D1117),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFF30363D)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header with score
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: color.withOpacity(0.2),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Icon(
+                    _getIcon(),
+                    size: 20,
+                    color: color,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'CONFIDENCE',
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 10,
+                          fontWeight: FontWeight.bold,
+                          color: const Color(0xFF8B949E),
+                          letterSpacing: 1,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        confidence.displayLabel,
+                        style: TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: color,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // Score badge
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: color.withOpacity(0.2),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Text(
+                    confidence.percentageString,
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: color,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // Progress bar
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: confidence.score,
+                backgroundColor: const Color(0xFF30363D),
+                valueColor: AlwaysStoppedAnimation(color),
+                minHeight: 8,
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 16),
+          const Divider(color: Color(0xFF30363D), height: 1),
+
+          // Reasoning
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'REASONING',
+                  style: TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 10,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF6E7681),
+                    letterSpacing: 0.5,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  confidence.reasoning,
+                  style: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 12,
+                    color: Color(0xFFE6EDF3),
+                    height: 1.4,
+                  ),
+                ),
+                if (confidence.risks != null && confidence.risks!.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  const Text(
+                    'RISKS',
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontSize: 10,
+                      fontWeight: FontWeight.bold,
+                      color: Color(0xFF6E7681),
+                      letterSpacing: 0.5,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFF85149).withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: const Color(0xFFF85149).withOpacity(0.3),
+                      ),
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Icon(
+                          Icons.warning_amber,
+                          size: 16,
+                          color: Color(0xFFF85149),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            confidence.risks!,
+                            style: const TextStyle(
+                              fontFamily: 'monospace',
+                              fontSize: 12,
+                              color: Color(0xFFE6EDF3),
+                              height: 1.4,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  IconData _getIcon() {
+    if (confidence.score >= 0.8) return Icons.check_circle;
+    if (confidence.score >= 0.5) return Icons.info;
+    return Icons.warning;
+  }
+}
+
+/// Compact chip showing confidence score for status bars
+class ConfidenceChip extends StatelessWidget {
+  final JobConfidence? confidence;
+  final VoidCallback? onTap;
+
+  const ConfidenceChip({
+    super.key,
+    this.confidence,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (confidence == null) return const SizedBox.shrink();
+
+    return ConfidenceIndicator(
+      confidence: confidence!,
+      compact: true,
+      onTap: onTap,
+    );
+  }
+}

--- a/test/models/job_confidence_test.dart
+++ b/test/models/job_confidence_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ops_deck/models/job_model.dart';
+
+void main() {
+  group('JobConfidence', () {
+    test('fromJson parses complete confidence', () {
+      final json = {
+        'score': 0.85,
+        'assessment': 'HIGH',
+        'reasoning': 'Straightforward feature using established patterns',
+        'risks': 'None identified',
+      };
+
+      final confidence = JobConfidence.fromJson(json);
+
+      expect(confidence.score, 0.85);
+      expect(confidence.assessment, 'HIGH');
+      expect(confidence.reasoning, 'Straightforward feature using established patterns');
+      expect(confidence.risks, 'None identified');
+    });
+
+    test('fromJson handles minimal confidence', () {
+      final json = {
+        'score': 0.5,
+        'reasoning': 'Some complexity involved',
+      };
+
+      final confidence = JobConfidence.fromJson(json);
+
+      expect(confidence.score, 0.5);
+      expect(confidence.assessment, 'MEDIUM');
+      expect(confidence.reasoning, 'Some complexity involved');
+      expect(confidence.risks, null);
+    });
+
+    test('fromJson clamps score to valid range', () {
+      expect(JobConfidence.fromJson({'score': 1.5}).score, 1.0);
+      expect(JobConfidence.fromJson({'score': -0.5}).score, 0.0);
+      expect(JobConfidence.fromJson({'score': 0.75}).score, 0.75);
+    });
+
+    test('fromJson handles string score', () {
+      final confidence = JobConfidence.fromJson({'score': '0.65'});
+      expect(confidence.score, 0.65);
+    });
+
+    test('fromJson handles int score', () {
+      final confidence = JobConfidence.fromJson({'score': 1});
+      expect(confidence.score, 1.0);
+    });
+
+    test('colorValue returns correct colors', () {
+      // High confidence - green
+      expect(
+        JobConfidence(score: 0.9, assessment: 'HIGH', reasoning: '').colorValue,
+        0xFF3FB950,
+      );
+
+      // Medium confidence - yellow
+      expect(
+        JobConfidence(score: 0.6, assessment: 'MEDIUM', reasoning: '').colorValue,
+        0xFFD29922,
+      );
+
+      // Low confidence - red
+      expect(
+        JobConfidence(score: 0.3, assessment: 'LOW', reasoning: '').colorValue,
+        0xFFF85149,
+      );
+    });
+
+    test('displayLabel returns correct labels', () {
+      expect(
+        JobConfidence(score: 0.9, assessment: 'HIGH', reasoning: '').displayLabel,
+        'High Confidence',
+      );
+      expect(
+        JobConfidence(score: 0.6, assessment: 'MEDIUM', reasoning: '').displayLabel,
+        'Medium Confidence',
+      );
+      expect(
+        JobConfidence(score: 0.3, assessment: 'LOW', reasoning: '').displayLabel,
+        'Low Confidence',
+      );
+    });
+
+    test('percentageString formats correctly', () {
+      expect(
+        JobConfidence(score: 0.85, assessment: 'HIGH', reasoning: '').percentageString,
+        '85%',
+      );
+      expect(
+        JobConfidence(score: 0.333, assessment: 'LOW', reasoning: '').percentageString,
+        '33%',
+      );
+    });
+  });
+
+  group('Job with confidence', () {
+    test('parses confidence from JSON', () {
+      final json = {
+        'status': 'completed',
+        'command': 'implement',
+        'start_time': 1706300000,
+        'repo': 'owner/repo',
+        'repo_slug': 'repo',
+        'issue_title': 'Test Issue',
+        'issue_num': 123,
+        'log_path': '/path/to/log',
+        'local_path': '/path/to/local',
+        'full_command': 'implement-headless',
+        'confidence': {
+          'score': 0.85,
+          'assessment': 'HIGH',
+          'reasoning': 'Standard implementation',
+          'risks': 'None',
+        },
+      };
+
+      final job = Job.fromJson('test-job-id', json);
+
+      expect(job.confidence, isNotNull);
+      expect(job.confidence!.score, 0.85);
+      expect(job.confidence!.assessment, 'HIGH');
+    });
+
+    test('handles missing confidence field', () {
+      final json = {
+        'status': 'completed',
+        'command': 'implement',
+        'start_time': 1706300000,
+        'repo': 'owner/repo',
+        'repo_slug': 'repo',
+        'issue_title': 'Test Issue',
+        'issue_num': 123,
+        'log_path': '/path/to/log',
+        'local_path': '/path/to/local',
+        'full_command': 'implement-headless',
+      };
+
+      final job = Job.fromJson('test-job-id', json);
+
+      expect(job.confidence, isNull);
+    });
+
+    test('handles null confidence field', () {
+      final json = {
+        'status': 'completed',
+        'command': 'implement',
+        'start_time': 1706300000,
+        'repo': 'owner/repo',
+        'repo_slug': 'repo',
+        'issue_title': 'Test Issue',
+        'issue_num': 123,
+        'log_path': '/path/to/log',
+        'local_path': '/path/to/local',
+        'full_command': 'implement-headless',
+        'confidence': null,
+      };
+
+      final job = Job.fromJson('test-job-id', json);
+
+      expect(job.confidence, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add visual confidence indicator showing Claude's certainty about implementation approach
- Display confidence chip in issue detail status bar with tap-to-expand details
- Full confidence view shows progress bar, reasoning, and any identified risks
- Color-coded (green/yellow/red) based on confidence level

## Changes
- **JobConfidence model**: Score (0-1), assessment (HIGH/MEDIUM/LOW), reasoning, risks
- **ConfidenceIndicator widget**: Full and compact views with progress bar
- **Issue detail screen**: Confidence chip in status bar, expandable section in Details tab
- **implement-headless.md**: Added `<<<CONFIDENCE>>>` structured format
- **11 unit tests** for parsing and display logic

## Server Integration
Requires claude-ops to parse the `<<<CONFIDENCE>>>` block from job logs and include in job response.

## Test plan
- [ ] Run implementation job with updated implement-headless command
- [ ] Verify confidence chip appears in status bar when job completes
- [ ] Tap chip to view full confidence details in bottom sheet
- [ ] Verify colors match confidence levels (green=high, yellow=medium, red=low)
- [ ] Run `flutter test test/models/job_confidence_test.dart` - all 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)