### PR TITLE
feat: Add local notifications for job completion events

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,8 @@ import 'providers/issue_board_provider.dart';
 import 'providers/quick_session_provider.dart';
 import 'providers/preview_provider.dart';
 import 'screens/kanban_board_screen.dart';
+import 'screens/issue_detail_screen.dart';
+import 'services/notification_service.dart';
 
 // Handle background messages
 @pragma('vm:entry-point')
@@ -60,11 +62,86 @@ class OpsDeckApp extends StatefulWidget {
   State<OpsDeckApp> createState() => _OpsDeckAppState();
 }
 
-class _OpsDeckAppState extends State<OpsDeckApp> {
+class _OpsDeckAppState extends State<OpsDeckApp> with WidgetsBindingObserver {
+  /// Global navigator key for notification deep linking
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
+
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _setupFirebaseMessaging();
+    _setupNotificationService();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final notificationService = NotificationService();
+
+    switch (state) {
+      case AppLifecycleState.resumed:
+        // App returned to foreground
+        notificationService.isInForeground = true;
+        if (kDebugMode) {
+          print('[OpsDeckApp] App resumed - refreshing data');
+        }
+        // Trigger data refresh
+        _refreshDataOnResume();
+        break;
+      case AppLifecycleState.paused:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.hidden:
+        // App went to background
+        notificationService.isInForeground = false;
+        if (kDebugMode) {
+          print('[OpsDeckApp] App paused/inactive');
+        }
+        break;
+      case AppLifecycleState.detached:
+        // App is detached
+        break;
+    }
+  }
+
+  void _refreshDataOnResume() {
+    // Get the IssueBoardProvider and refresh
+    final context = _navigatorKey.currentContext;
+    if (context != null) {
+      try {
+        final provider = Provider.of<IssueBoardProvider>(context, listen: false);
+        provider.fetchJobs();
+      } catch (e) {
+        if (kDebugMode) {
+          print('[OpsDeckApp] Failed to refresh on resume: $e');
+        }
+      }
+    }
+  }
+
+  Future<void> _setupNotificationService() async {
+    final notificationService = NotificationService();
+    await notificationService.initialize();
+
+    // Handle notification taps - navigate to issue detail
+    notificationService.onNotificationTap = (repo, issueNum) {
+      if (kDebugMode) {
+        print('[OpsDeckApp] Notification tap: $repo #$issueNum');
+      }
+      _navigatorKey.currentState?.push(
+        MaterialPageRoute(
+          builder: (context) => IssueDetailScreen(
+            repo: repo,
+            issueNum: issueNum,
+          ),
+        ),
+      );
+    };
   }
 
   Future<void> _setupFirebaseMessaging() async {
@@ -170,6 +247,7 @@ class _OpsDeckAppState extends State<OpsDeckApp> {
         ChangeNotifierProvider(create: (_) => PreviewProvider()),
       ],
       child: MaterialApp(
+        navigatorKey: _navigatorKey,
         title: 'Ops Deck',
         debugShowCheckedModeBanner: false,
         theme: _buildTheme(),

--- a/lib/providers/issue_board_provider.dart
+++ b/lib/providers/issue_board_provider.dart
@@ -6,6 +6,7 @@ import '../models/file_diff_model.dart';
 import '../services/api_service.dart';
 import '../services/websocket_service.dart';
 import '../services/job_cache_service.dart';
+import '../services/notification_service.dart';
 
 /// Callback type for showing toast notifications
 typedef ToastCallback = void Function(String message, {VoidCallback? onUndo});
@@ -260,12 +261,20 @@ class IssueBoardProvider with ChangeNotifier {
     switch (event.type) {
       case JobEventType.jobCreated:
       case JobEventType.jobStatusChanged:
+        // Update or create the issue with new job status
+        _updateIssueFromEvent(issueKey, job);
+        // Update cache with new status
+        _cache.updateJobStatus(job.id, job.status);
+        notifyListeners();
+        break;
       case JobEventType.jobCompleted:
       case JobEventType.jobFailed:
         // Update or create the issue with new job status
         _updateIssueFromEvent(issueKey, job);
         // Update cache with new status
         _cache.updateJobStatus(job.id, job.status);
+        // Show notification if app is in background
+        _maybeShowNotification(event);
         notifyListeners();
         break;
       case JobEventType.previewStatusChanged:
@@ -276,6 +285,34 @@ class IssueBoardProvider with ChangeNotifier {
         break;
       case JobEventType.unknown:
         break;
+    }
+  }
+
+  /// Show notification for job completion/failure if app is in background
+  void _maybeShowNotification(JobEvent event) {
+    final notificationService = NotificationService();
+
+    // Skip if app is in foreground - user will see snackbar instead
+    if (notificationService.isInForeground) {
+      return;
+    }
+
+    final job = event.job;
+
+    if (event.type == JobEventType.jobCompleted) {
+      notificationService.showJobCompletedNotification(
+        issueTitle: job.issueTitle,
+        issueNum: job.issueNum,
+        repo: job.repo,
+        command: job.command,
+      );
+    } else if (event.type == JobEventType.jobFailed) {
+      notificationService.showJobFailedNotification(
+        issueTitle: job.issueTitle,
+        issueNum: job.issueNum,
+        repo: job.repo,
+        command: job.command,
+      );
     }
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+/// Callback type for handling notification taps
+typedef NotificationTapCallback = void Function(String repo, int issueNum);
+
+/// Singleton service for local notifications
+/// Shows notifications for job completion/failure events when app is in background
+class NotificationService {
+  static final NotificationService _instance = NotificationService._internal();
+  factory NotificationService() => _instance;
+  NotificationService._internal();
+
+  final FlutterLocalNotificationsPlugin _notifications =
+      FlutterLocalNotificationsPlugin();
+
+  /// Whether the app is currently in the foreground
+  bool isInForeground = true;
+
+  /// Callback for when user taps a notification
+  NotificationTapCallback? onNotificationTap;
+
+  /// Notification ID counter
+  int _notificationId = 0;
+
+  /// Initialize the notification service
+  Future<void> initialize() async {
+    // Android initialization settings
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    // iOS initialization settings
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+
+    const initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _notifications.initialize(
+      initSettings,
+      onDidReceiveNotificationResponse: _onNotificationTap,
+    );
+
+    // Create Android notification channel
+    await _createAndroidChannel();
+
+    // Request permissions on iOS
+    await _requestPermissions();
+
+    if (kDebugMode) {
+      print('[NotificationService] Initialized');
+    }
+  }
+
+  /// Create the Android notification channel for job events
+  Future<void> _createAndroidChannel() async {
+    const channel = AndroidNotificationChannel(
+      'job_events',
+      'Job Events',
+      description: 'Notifications for job completion and failure events',
+      importance: Importance.high,
+    );
+
+    await _notifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(channel);
+  }
+
+  /// Request notification permissions on iOS
+  Future<void> _requestPermissions() async {
+    // iOS
+    await _notifications
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+
+    // Android 13+
+    await _notifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
+  }
+
+  /// Handle notification tap
+  void _onNotificationTap(NotificationResponse response) {
+    if (kDebugMode) {
+      print('[NotificationService] Notification tapped: ${response.payload}');
+    }
+
+    final payload = response.payload;
+    if (payload == null || payload.isEmpty) return;
+
+    // Parse payload: "repo|issueNum"
+    final parts = payload.split('|');
+    if (parts.length != 2) return;
+
+    final repo = parts[0];
+    final issueNum = int.tryParse(parts[1]);
+    if (issueNum == null) return;
+
+    // Invoke callback
+    onNotificationTap?.call(repo, issueNum);
+  }
+
+  /// Show a notification for a job event
+  /// [title] - e.g., "Job Completed" or "Job Failed"
+  /// [body] - e.g., "#123: Feature implementation"
+  /// [repo] - Repository for deep linking
+  /// [issueNum] - Issue number for deep linking
+  Future<void> showJobNotification({
+    required String title,
+    required String body,
+    required String repo,
+    required int issueNum,
+  }) async {
+    // Don't show if app is in foreground - snackbar will handle it
+    if (isInForeground) {
+      if (kDebugMode) {
+        print('[NotificationService] Skipping notification (app in foreground)');
+      }
+      return;
+    }
+
+    final id = _notificationId++;
+    final payload = '$repo|$issueNum';
+
+    const androidDetails = AndroidNotificationDetails(
+      'job_events',
+      'Job Events',
+      channelDescription: 'Notifications for job completion and failure events',
+      importance: Importance.high,
+      priority: Priority.high,
+      icon: '@mipmap/ic_launcher',
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notifications.show(
+      id,
+      title,
+      body,
+      details,
+      payload: payload,
+    );
+
+    if (kDebugMode) {
+      print('[NotificationService] Showed notification: $title - $body');
+    }
+  }
+
+  /// Show a notification for job completion
+  Future<void> showJobCompletedNotification({
+    required String issueTitle,
+    required int issueNum,
+    required String repo,
+    required String command,
+  }) async {
+    final commandLabel = _formatCommand(command);
+    await showJobNotification(
+      title: 'Job Completed',
+      body: '#$issueNum: $issueTitle ($commandLabel)',
+      repo: repo,
+      issueNum: issueNum,
+    );
+  }
+
+  /// Show a notification for job failure
+  Future<void> showJobFailedNotification({
+    required String issueTitle,
+    required int issueNum,
+    required String repo,
+    required String command,
+  }) async {
+    final commandLabel = _formatCommand(command);
+    await showJobNotification(
+      title: 'Job Failed',
+      body: '#$issueNum: $issueTitle ($commandLabel)',
+      repo: repo,
+      issueNum: issueNum,
+    );
+  }
+
+  /// Format command name for display
+  String _formatCommand(String command) {
+    switch (command) {
+      case 'plan-headless':
+        return 'Plan';
+      case 'implement-headless':
+        return 'Implement';
+      case 'revise-headless':
+        return 'Revise';
+      case 'retrospective-headless':
+        return 'Retrospective';
+      default:
+        return command;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `NotificationService` singleton for local notifications using `flutter_local_notifications`
- Create Android notification channel "job_events" with high importance
- Show notifications when jobs complete/fail while app is in background
- Handle notification taps to deep link to `IssueDetailScreen`
- Add `WidgetsBindingObserver` for app lifecycle tracking
- Auto-refresh data when app returns to foreground

## Behavior

| App State | Job Event | Result |
|-----------|-----------|--------|
| Foreground | Completes/Fails | Existing snackbar (no change) |
| Background | Completes/Fails | Local notification shown |
| Notification tapped | - | Navigate to IssueDetailScreen |
| App resumed | - | Auto-refresh job data |

## Test plan

- [x] Trigger a job, switch to another app, wait for completion, verify notification appears
- [x] Stay in app during job completion, verify only snackbar shows (no duplicate notification)
- [x] Tap notification, verify navigates to correct issue
- [x] Background app, wait, resume, verify data refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)