### PR TITLE
fix: Resolve issue status sync bugs causing stale UI state

### DIFF
--- a/lib/providers/issue_board_provider.dart
+++ b/lib/providers/issue_board_provider.dart
@@ -268,12 +268,38 @@ class IssueBoardProvider with ChangeNotifier {
         notifyListeners();
         break;
       case JobEventType.jobCompleted:
+        // Ensure status is 'completed' even if not in event payload
+        final completedJob = JobEventData(
+          id: job.id,
+          repo: job.repo,
+          issueNum: job.issueNum,
+          issueTitle: job.issueTitle,
+          command: job.command,
+          status: job.status.isEmpty ? 'completed' : job.status,
+          cost: job.cost,
+          preview: job.preview,
+          testResults: job.testResults,
+        );
+        _updateIssueFromEvent(issueKey, completedJob);
+        _cache.updateJobStatus(completedJob.id, completedJob.status);
+        _maybeShowNotification(event);
+        notifyListeners();
+        break;
       case JobEventType.jobFailed:
-        // Update or create the issue with new job status
-        _updateIssueFromEvent(issueKey, job);
-        // Update cache with new status
-        _cache.updateJobStatus(job.id, job.status);
-        // Show notification if app is in background
+        // Ensure status is 'failed' even if not in event payload
+        final failedJob = JobEventData(
+          id: job.id,
+          repo: job.repo,
+          issueNum: job.issueNum,
+          issueTitle: job.issueTitle,
+          command: job.command,
+          status: job.status.isEmpty ? 'failed' : job.status,
+          cost: job.cost,
+          preview: job.preview,
+          testResults: job.testResults,
+        );
+        _updateIssueFromEvent(issueKey, failedJob);
+        _cache.updateJobStatus(failedJob.id, failedJob.status);
         _maybeShowNotification(event);
         notifyListeners();
         break;
@@ -502,11 +528,17 @@ class IssueBoardProvider with ChangeNotifier {
       if (oldIssue.status != entry.value.status) return true;
       if (oldIssue.currentPhase != entry.value.currentPhase) return true;
       if (oldIssue.jobs.length != entry.value.jobs.length) return true;
-      // Check if any job has new decisions
-      for (int i = 0; i < oldIssue.jobs.length && i < entry.value.jobs.length; i++) {
-        if (oldIssue.jobs[i].decisions.length != entry.value.jobs[i].decisions.length) {
-          return true;
-        }
+      // Check completedPhases
+      if (oldIssue.completedPhases.length != entry.value.completedPhases.length) {
+        return true;
+      }
+      // Check if any job status or decisions changed (match by job ID, not index)
+      final oldJobsById = {for (var j in oldIssue.jobs) j.issueId: j};
+      for (final newJob in entry.value.jobs) {
+        final oldJob = oldJobsById[newJob.issueId];
+        if (oldJob == null) return true; // New job added
+        if (oldJob.status != newJob.status) return true;
+        if (oldJob.decisions.length != newJob.decisions.length) return true;
       }
     }
     return false;


### PR DESCRIPTION
## Summary

Fixes two bugs that caused issues to show incorrect status or disappear from the Kanban board:

- **Issue #47** disappeared after implement completed
- **Issue #114** was stuck showing "implementing" even though retrospective was completed

### Bug 1: `_hasIssuesChanged()` didn't detect job status changes

The change detection method compared jobs by array index and didn't check individual job statuses. When a job changed from "running" to "completed" but the issue had the same number of jobs, the change wasn't detected and `_issues` wasn't updated with fresh server data.

**Fix:** Now matches jobs by ID and properly compares job statuses.

### Bug 2: WebSocket events with empty status field

When `jobCompleted` or `jobFailed` WebSocket events arrived without a `status` field (or empty), the job's status became `JobStatus.unknown`. This meant:
- Jobs weren't counted in `completedPhases`
- Issues got stuck showing old workflow phase (e.g., "implementing")
- Pull-to-refresh didn't help because change detection failed

**Fix:** Now explicitly sets status to "completed"/"failed" based on event type when the payload is missing status.

## Test plan

- [x] Verify Issue #47 appears in Needs Action column after refresh
- [x] Verify Issue #114 shows as Done (or in Done search) after refresh
- [x] Test job completion flow: start a job, watch it complete, verify status updates correctly
- [x] Test pull-to-refresh updates stale issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)