### PR TITLE
fix: Add type checks to error response parsing

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -187,11 +187,12 @@ class ApiService {
       final data = json.decode(response.body);
 
       // Check common error message fields in order of specificity
-      serverMessage = data['reason'] as String? ??
-          data['error'] as String? ??
-          data['message'] as String? ??
-          data['detail'] as String? ??
-          data['error_description'] as String? ??
+      // Use type checks to avoid crashes when server returns unexpected types
+      serverMessage = (data['reason'] is String ? data['reason'] as String : null) ??
+          (data['error'] is String ? data['error'] as String : null) ??
+          (data['message'] is String ? data['message'] as String : null) ??
+          (data['detail'] is String ? data['detail'] as String : null) ??
+          (data['error_description'] is String ? data['error_description'] as String : null) ??
           (data['details'] is String ? data['details'] as String : null) ??
           (data['errors'] is List && (data['errors'] as List).isNotEmpty
               ? (data['errors'] as List).map((e) => e.toString()).join('; ')


### PR DESCRIPTION
## Summary

Fixes crash when server returns unexpected types in error responses.

The `_handleErrorResponse` method was casting error fields directly to `String?` without checking their type first. If the server returned a `List` for fields like `reason`, `error`, or `message`, it would crash with:

```
type List<dynamic> is not a subtype of type 'String?' in type cast
```

This was causing "Connection Error" on app startup when the server returned an error with a non-string field.

## Changes

Added type checks (`is String`) before casting for all error message fields, matching the existing pattern already used for the `details` field.

## Test plan

- [x] Verify app connects successfully without type cast errors
- [x] Test error handling with various server error response formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)