### PR TITLE
feat: Add release signing for consistent APK updates

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Create google-services.json
         run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
 
+      - name: Setup release signing
+        run: |
+          echo '${{ secrets.KEYSTORE_BASE64 }}' | base64 --decode > android/app/ops-deck-release.keystore
+          echo "storeFile=ops-deck-release.keystore" > android/key.properties
+          echo "storePassword=${{ secrets.KEYSTORE_PASSWORD }}" >> android/key.properties
+          echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
+          echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
+
       - name: Setup Java
         uses: actions/setup-java@v5
         with:
@@ -56,6 +64,7 @@ jobs:
           groups: testers
           file: build/app/outputs/flutter-apk/app-release.apk
           releaseNotes: |
+            Build: ${{ github.run_number }}
             Commit: ${{ github.sha }}
             Branch: ${{ github.ref_name }}
             Message: ${{ github.event.head_commit.message }}

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,18 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Load key.properties file if it exists (for release signing)
+val keyPropertiesFile = rootProject.file("key.properties")
+val keyProperties = Properties()
+if (keyPropertiesFile.exists()) {
+    keyProperties.load(FileInputStream(keyPropertiesFile))
 }
 
 android {
@@ -22,11 +32,19 @@ android {
         }
     }
 
+    signingConfigs {
+        if (keyPropertiesFile.exists()) {
+            create("release") {
+                keyAlias = keyProperties["keyAlias"] as String
+                keyPassword = keyProperties["keyPassword"] as String
+                storeFile = file(keyProperties["storeFile"] as String)
+                storePassword = keyProperties["storePassword"] as String
+            }
+        }
+    }
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.claudeops.opsdeck"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -35,9 +53,11 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (keyPropertiesFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where Firebase App Distribution shows "not installed" when trying to update the app. This was caused by each CI build having a different signature (using auto-generated debug keystores).

## Changes

- **build.gradle.kts**: Load signing config from `key.properties` when available, fall back to debug signing for local development
- **distribute.yml**: Decode keystore from secrets and create `key.properties` file during CI builds
- Added build number to release notes for easier debugging

## Required GitHub Secrets

Add these secrets at https://github.com/LeeW7/ops-deck/settings/secrets/actions:

| Secret | Value |
|--------|-------|
| `KEYSTORE_BASE64` | Base64-encoded keystore (provided separately) |
| `KEYSTORE_PASSWORD` | `opsdeck123` |
| `KEY_ALIAS` | `ops-deck` |
| `KEY_PASSWORD` | `opsdeck123` |

## Test plan

1. Add the GitHub secrets
2. Merge this PR
3. Wait for the build to complete
4. **Uninstall** the current app (required once since signature changed)
5. Install from Firebase App Distribution
6. Future updates should work without uninstalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)